### PR TITLE
Get ip address which AddressFamily == InterNetwork when isDns

### DIFF
--- a/WebuSocket/WebuSocket.cs
+++ b/WebuSocket/WebuSocket.cs
@@ -243,10 +243,16 @@ namespace WebuSocketCore {
 								return;
 							}
 
-							// choose 1st ip.
-							var ip = addresses.AddressList[0];	
-							this.endPoint = new IPEndPoint(ip, port);
-
+							// choose valid ip.
+							foreach (IPAddress ipaddress in addresses.AddressList){
+								 if (ipaddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) {
+										this.endPoint = new IPEndPoint(ipaddress, port);
+										StartConnectAsync();
+										return;
+								 }
+							 }
+							var unresolvedAddressFamilyException = new Exception("failed to get valid address family from list.");
+							OnError(WebuSocketErrorEnum.DOMAIN_UNRESOLVED, unresolvedAddressFamilyException);
 							StartConnectAsync();
 						}
 					),


### PR DESCRIPTION
Hi,
This pull request is for fixing this issue: https://github.com/sassembla/WebuSocket/issues/19 .

## Changes:

-  Added Check of AddressFamily of IP Addresses  when setting WebuSocket endPoint.
  - Because the head item of addresses.AddressList is not guaranteed IPv4 Address(=AddressFamily.InterNetwork)